### PR TITLE
expose port 8080 - not 8081

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ ENV VERTICLE_HOME /usr/verticles
 COPY target/${VERTICLE_FILE} ${VERTICLE_HOME}/${VERTICLE_FILE}
 
 # Expose this port locally in the container.
-EXPOSE 8081
+EXPOSE 8080


### PR DESCRIPTION
As near as I can tell,   this module runs on port 8080 - not 8081.  Therefore,  we need to expose port 8080 in the Dockerfile. 