### PR TITLE
MODHAADM-16: Vert.x 4.3.4 fixing snakeyaml vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <okapi.version>5.0.0-SNAPSHOT</okapi.version>
-        <vertx.version>4.3.3</vertx.version>
+        <vertx.version>4.3.4</vertx.version>
         <maven.compiler.source>18</maven.compiler.source>
         <maven.compiler.target>18</maven.compiler.target>
         <maven.test.skip>true</maven.test.skip>


### PR DESCRIPTION
Upgrade vertx from 4.3.3 to 4.3.4. This indirectly upgrades snakeyaml from 1.30 to 1.32 fixing Denial of Service (DoS) and Stack-based Buffer Overflow: https://nvd.nist.gov/vuln/detail/CVE-2022-25857
https://nvd.nist.gov/vuln/detail/CVE-2022-38749
https://nvd.nist.gov/vuln/detail/CVE-2022-38751
https://nvd.nist.gov/vuln/detail/CVE-2022-38752
https://nvd.nist.gov/vuln/detail/CVE-2022-38750