### PR TITLE
Work-around for delayed consistency in Harvester

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -51,7 +51,7 @@
           "pathPattern": "/harvester-admin/harvestables/{id}/log",
           "permissionsRequired": ["harvester-admin.harvestables.log.get"]
         }, {
-          "methods": ["GET"],
+          "methods": ["GET", "POST"],
           "pathPattern": "/harvester-admin/harvestables/{id}/log/store",
           "permissionsRequired": ["harvester-admin.harvestables.log.store"]
         }, {

--- a/src/main/java/org/folio/harvesteradmin/dataaccess/LegacyHarvesterStorage.java
+++ b/src/main/java/org/folio/harvesteradmin/dataaccess/LegacyHarvesterStorage.java
@@ -761,10 +761,12 @@ public class LegacyHarvesterStorage {
             JsonArray failedRecords = new JsonArray();
             response.put("failed-records", failedRecords);
             for (int i = 0; i < results.result().list().size(); i++) {
-              JsonObject record = ((ProcessedHarvesterResponseGetById) results
-                  .result().resultAt(i)).jsonObject();
-              record.getJsonObject("failed-record").put("harvestableId",harvestableId);
-              failedRecords.add(record.getJsonObject("failed-record"));
+              if (results.result().resultAt(i) != null) {
+                JsonObject record = ((ProcessedHarvesterResponseGetById) results
+                    .result().resultAt(i)).jsonObject();
+                record.getJsonObject("failed-record").put("harvestableId", harvestableId);
+                failedRecords.add(record.getJsonObject("failed-record"));
+              }
             }
             response.put("totalRecords", failedRecords.size());
             promise.complete(new ProcessedHarvesterResponseGet(response, 200, null));
@@ -818,13 +820,18 @@ public class LegacyHarvesterStorage {
     String uri = entry.getString("url");
     harvesterGetRequest(uri)
         .send(ar ->  {
-          ProcessedHarvesterResponseGetById response =
-              new ProcessedHarvesterResponseGetById(ar,uri,"","");
-          response.jsonObject().getJsonObject("failed-record")
-              .put("timeStamp", entry.getJsonObject("file").getString("date"));
-          response.jsonObject().getJsonObject("failed-record")
-              .put("recordNumber", entry.getJsonObject("file").getString("name"));
-          promise.complete(response);
+          if (ar.result().bodyAsString() != null) {
+            ProcessedHarvesterResponseGetById response =
+                new ProcessedHarvesterResponseGetById(ar, uri, "", "");
+            response.jsonObject().getJsonObject("failed-record")
+                .put("timeStamp", entry.getJsonObject("file").getString("date"));
+            response.jsonObject().getJsonObject("failed-record")
+                .put("recordNumber", entry.getJsonObject("file").getString("name"));
+            promise.complete(response);
+          } else {
+            promise.complete(null);
+          }
+
         });
     return promise.future();
   }

--- a/src/main/java/org/folio/harvesteradmin/moduledata/HarvestJob.java
+++ b/src/main/java/org/folio/harvesteradmin/moduledata/HarvestJob.java
@@ -48,7 +48,8 @@ public class HarvestJob extends StoredEntity {
     harvestJob.setStatus(harvestableJson.getString("currentStatus"));
     harvestJob.setStartedAndFinished(
         harvestableJson.getString("lastHarvestStarted"),
-        harvestableJson.getString("lastHarvestFinished"));
+        harvestableJson.getString("lastHarvestFinished")
+    );
     harvestJob.setAmountHarvested(harvestableJson.getString("amountHarvested"));
     harvestJob.setMessage(harvestableJson.getString("message"));
     return harvestJob;
@@ -324,16 +325,20 @@ public class HarvestJob extends StoredEntity {
   }
 
   public void setFinished(LocalDateTime finished) {
-    json.put(HarvestJobField.FINISHED.propertyName(), finished.toString());
+    setFinished(finished.toString());
+  }
+
+  public void setFinished(String finished) {
+    json.put(HarvestJobField.FINISHED.propertyName(), finished);
   }
 
   /**
    * Sets start and finish dates.
    */
   public void setStartedAndFinished(String started, String finished) {
-    if (started != null && finished != null) {
+    if (started != null) {
       json.put(HarvestJobField.STARTED.propertyName(), started);
-      if (started.compareTo(finished) < 0) { // or else it's the finish time of an earlier job
+      if (finished != null && started.compareTo(finished) < 0) {
         json.put(HarvestJobField.FINISHED.propertyName(), finished);
       }
     }

--- a/src/main/java/org/folio/harvesteradmin/moduledata/HarvestJobField.java
+++ b/src/main/java/org/folio/harvesteradmin/moduledata/HarvestJobField.java
@@ -11,7 +11,7 @@ public enum HarvestJobField implements Field {
   BATCH_SIZE("batchSize", "batch_size", PgColumn.Type.INTEGER, true, false),
   TRANSFORMATION("transformation", "transformation", PgColumn.Type.TEXT, false, false),
   STORAGE("storage", "storage", PgColumn.Type.TEXT, false, false),
-  STATUS("status", "status", PgColumn.Type.TEXT, false, true),
+  STATUS("status", "status", PgColumn.Type.TEXT, true, true),
   STARTED("started", "started", PgColumn.Type.TIMESTAMP, false, false),
   FINISHED("finished", "finished", PgColumn.Type.TIMESTAMP, true, false),
   AMOUNT_HARVESTED("amountHarvested", "amount_harvested", PgColumn.Type.INTEGER, true, false),

--- a/src/main/resources/openapi/harvest-admin-1.0.yaml
+++ b/src/main/resources/openapi/harvest-admin-1.0.yaml
@@ -255,9 +255,27 @@ paths:
         description: Harvest configuration identifier
         schema:
           type: string
+    post:
+      description: Takes submitted job status, pulls the job config, and stores a copy of its most recent logs
+      operationId: storeJobLogWithPostedStatus
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/harvestJobStatus"
+        required: true
+      responses:
+        "200":
+          description: Harvest log statements stored in module storage
+        "400":
+          $ref: "#/components/responses/trait_400"
+        "404":
+          $ref: "#/components/responses/trait_404"
+        "500":
+          $ref: "#/components/responses/trait_500"
     get:
       operationId: storeJobLog
-      description: Stores a copy of the most recent log for a harvest job
+      description: Pulls the current job config from Harvester and stores a copy of the most recent log for that job
       responses:
         "200":
           description: Harvest log statements stored in module storage
@@ -918,3 +936,5 @@ components:
       $ref: schemas/transformationStepAssociation.json
     transformationStepAssociations:
       $ref: schemas/transformationStepAssociations.json
+    harvestJobStatus:
+      $ref: schemas/harvestJobStatus.json

--- a/src/main/resources/openapi/schemas/harvestJobStatus.json
+++ b/src/main/resources/openapi/schemas/harvestJobStatus.json
@@ -1,0 +1,20 @@
+{
+  "description": "Status of finished harvest job.",
+  "type": "object",
+  "properties": {
+    "finished": {
+      "type": "string",
+      "description": "ISO formatted timestamp for when the job finished."
+    },
+    "amountHarvested": {
+      "type": "string",
+      "description": "The number of records harvested in the harvest run."
+    },
+    "message": {
+      "type": "string",
+      "description": "Status message for the outcome of the harvest run."
+    }
+  },
+  "additionalProperties": false,
+  "required": ["finished", "message"]
+}


### PR DESCRIPTION
 The status of a finished job is not written to storage right away so a job pulled through the WS API might have outdated information. Allow for the Harvester to send the correct status over when asking FOLIO to pull the job and logs.