### PR TITLE
Accept xmlBulk jobs too, add second line of schema validation (MODHAADM-23)

### DIFF
--- a/src/main/java/org/folio/harvesteradmin/service/SchemaValidation.java
+++ b/src/main/java/org/folio/harvesteradmin/service/SchemaValidation.java
@@ -1,0 +1,44 @@
+package org.folio.harvesteradmin.service;
+
+import io.vertx.core.json.JsonObject;
+
+public class SchemaValidation {
+  private boolean passed = true;
+  private String errorMessage = "";
+
+  /**
+   * Performs validations that are not supported by current Vert.X OpenApi validations.
+   */
+  public SchemaValidation(String endPoint, JsonObject input) {
+    if (endPoint.contains("harvestables")) {
+      if (input.getString("type").equals("oaiPmh")) {
+        if (!input.containsKey("oaiSetName")) {
+          passed = false;
+          errorMessage +=
+              "[Bad Request] Validation error for body application/json: "
+                  + "provided object should contain property oaiSetName"
+              + System.lineSeparator();
+        }
+        if (!input.containsKey("metadataPrefix")) {
+          passed = false;
+          errorMessage += "[Bad Request] Validation error for body application/json: "
+              + "provided object should contain property metadataPrefix"
+              + System.lineSeparator();
+        }
+      }
+    }
+  }
+
+  public static SchemaValidation validateJsonObject(String endPoint, JsonObject json) {
+    return new SchemaValidation(endPoint, json);
+  }
+
+  public boolean passed() {
+    return passed;
+  }
+
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+
+}

--- a/src/main/resources/openapi/schemas/harvestable.json
+++ b/src/main/resources/openapi/schemas/harvestable.json
@@ -13,7 +13,7 @@
     "type": {
       "type": "string",
       "enum": [
-        "oaiPmh"
+        "oaiPmh", "xmlBulk"
       ],
       "description": "The type of harvest configuration, ie. OAI-PMH or bulk XML."
     },
@@ -126,6 +126,6 @@
     }
   },
   "additionalProperties": true,
-  "required": ["name", "type", "enabled", "harvestImmediately", "storage", "transformation", "metadataPrefix", "oaiSetName", "url"]
+  "required": ["name", "type", "enabled", "harvestImmediately", "storage", "transformation", "url"]
 }
 


### PR DESCRIPTION
  - Only jobs with type 'oaiPmh' were accepted, and property 'oaiSetName' was thus required. Type 'xmlBulk' should be accepted too. The requirement for 'oaiSetName' is therefore conditional on the type, something the built-in schema validation does not support, so a second line of hand-coded schema validation is being added.