### PR TITLE
Fix PG column type and handling of big IDs in code (MODHAADM-21)

### DIFF
--- a/src/main/java/org/folio/harvesteradmin/moduledata/HarvestJob.java
+++ b/src/main/java/org/folio/harvesteradmin/moduledata/HarvestJob.java
@@ -179,7 +179,7 @@ public class HarvestJob extends StoredEntity {
       HarvestJob harvestJob = new HarvestJob();
       harvestJob.setId(row.getUUID(HarvestJobField.ID.columnName()));
       harvestJob.setName(row.getString(HarvestJobField.HARVESTABLE_NAME.columnName()));
-      harvestJob.setHarvestableId(row.getInteger(HarvestJobField.HARVESTABLE_ID.columnName()));
+      harvestJob.setHarvestableId(row.getLong(HarvestJobField.HARVESTABLE_ID.columnName()));
       harvestJob.setType(row.getString(HarvestJobField.HARVESTABLE_TYPE.columnName()));
       harvestJob.setUrl(row.getString(HarvestJobField.URL.columnName()));
       harvestJob.setAllowErrors(row.getBoolean(HarvestJobField.ALLOW_ERRORS.columnName()));
@@ -210,16 +210,16 @@ public class HarvestJob extends StoredEntity {
     json.put(HarvestJobField.ID.propertyName(), id);
   }
 
-  public int getHarvestableId() {
-    return json.getInteger(HarvestJobField.HARVESTABLE_ID.propertyName());
+  public long getHarvestableId() {
+    return json.getLong(HarvestJobField.HARVESTABLE_ID.propertyName());
   }
 
-  public void setHarvestableId(int harvestableId) {
+  public void setHarvestableId(long harvestableId) {
     json.put(HarvestJobField.HARVESTABLE_ID.propertyName(), harvestableId);
   }
 
   public void setHarvestableId(String harvestableId) {
-    setHarvestableId(Integer.parseInt(harvestableId));
+    setHarvestableId(Long.parseLong(harvestableId));
   }
 
   public String getName() {

--- a/src/main/java/org/folio/harvesteradmin/moduledata/HarvestJobField.java
+++ b/src/main/java/org/folio/harvesteradmin/moduledata/HarvestJobField.java
@@ -2,7 +2,7 @@ package org.folio.harvesteradmin.moduledata;
 
 public enum HarvestJobField implements Field {
   ID("id", "id", PgColumn.Type.UUID, false, true, true),
-  HARVESTABLE_ID("harvestableId", "harvestable_id", PgColumn.Type.INTEGER, false, true),
+  HARVESTABLE_ID("harvestableId", "harvestable_id", PgColumn.Type.BIGINT, false, true),
   HARVESTABLE_NAME("name", "harvestable_name", PgColumn.Type.TEXT, false, true),
   HARVESTABLE_TYPE("type", "type", PgColumn.Type.TEXT, false, true),
   URL("url", "url", PgColumn.Type.TEXT, false, false),

--- a/src/main/java/org/folio/harvesteradmin/moduledata/PgColumn.java
+++ b/src/main/java/org/folio/harvesteradmin/moduledata/PgColumn.java
@@ -15,6 +15,7 @@ public class PgColumn {
   enum Type {
     TEXT,
     INTEGER,
+    BIGINT,
     TIMESTAMP,
     UUID,
     BOOLEAN
@@ -41,6 +42,7 @@ public class PgColumn {
   public PgCqlFieldBase pgCqlField() {
     switch (type) {
       case INTEGER:
+      case BIGINT:
         return new PgCqlFieldNumber();
       case UUID:
         return new PgCqlFieldUuid();


### PR DESCRIPTION
  - The Postgres column for harvestable ID must be `bigint` to hold the new long numbers.
  - The code should not use Integer functions or variables but rather Long everywhere when handling harvestableIds