### PR TITLE
Support references by name in POSTs.

### DIFF
--- a/src/main/java/org/folio/harvesteradmin/dataaccess/statics/EntityRootNames.java
+++ b/src/main/java/org/folio/harvesteradmin/dataaccess/statics/EntityRootNames.java
@@ -30,13 +30,29 @@ public class EntityRootNames {
   static {
     rootOfEntityByHarvesterPath.put(HARVESTER_HARVESTABLES_PATH,
         EntityRootNames.HARVESTABLE_ROOT_PROPERTY);
-    rootOfEntityByHarvesterPath.put(HARVESTER_STORAGES_PATH, EntityRootNames.STORAGE_ROOT_PROPERTY);
+    rootOfEntityByHarvesterPath.put(HARVESTER_STORAGES_PATH,
+        EntityRootNames.STORAGE_ROOT_PROPERTY);
     rootOfEntityByHarvesterPath.put(HARVESTER_TRANSFORMATIONS_PATH,
         EntityRootNames.TRANSFORMATION_ROOT_PROPERTY);
-    rootOfEntityByHarvesterPath.put(HARVESTER_STEPS_PATH, EntityRootNames.STEP_ROOT_PROPERTY);
+    rootOfEntityByHarvesterPath.put(HARVESTER_STEPS_PATH,
+        EntityRootNames.STEP_ROOT_PROPERTY);
     rootOfEntityByHarvesterPath.put(HARVESTER_TSAS_PATH,
         EntityRootNames.TRANSFORMATION_STEP_ROOT_PROPERTY);
+  }
 
+  private static final Map<String, String> rootOfEntitiesByHarvesterPath = new HashMap<>();
+
+  static {
+    rootOfEntitiesByHarvesterPath.put(HARVESTER_HARVESTABLES_PATH,
+        EntityRootNames.HARVESTABLE_SET_ROOT_PROPERTY);
+    rootOfEntitiesByHarvesterPath.put(HARVESTER_STORAGES_PATH,
+        EntityRootNames.STORAGE_SET_ROOT_PROPERTY);
+    rootOfEntitiesByHarvesterPath.put(HARVESTER_TRANSFORMATIONS_PATH,
+        EntityRootNames.TRANSFORMATION_SET_ROOT_PROPERTY);
+    rootOfEntitiesByHarvesterPath.put(HARVESTER_STEPS_PATH,
+        EntityRootNames.STEP_SET_ROOT_PROPERTY);
+    rootOfEntitiesByHarvesterPath.put(HARVESTER_TSAS_PATH,
+        EntityRootNames.TRANSFORMATION_STEP_SET_ROOT_PROPERTY);
   }
 
   /**
@@ -49,6 +65,13 @@ public class EntityRootNames {
    */
   public static String mapToNameOfRootOfEntity(String harvesterPath) {
     return rootOfEntityByHarvesterPath.get(harvesterPath);
+  }
+
+  /**
+   * Get the Harvester's name for the array of entities from the requested Harvester path.
+   */
+  public static String mapToNameOfArrayOfEntities(String harvesterPath) {
+    return rootOfEntitiesByHarvesterPath.get(harvesterPath);
   }
 
   public static Map<String, String> typeToEmbeddedTypeMap = new HashMap<>();

--- a/src/main/java/org/folio/harvesteradmin/service/HarvestAdminService.java
+++ b/src/main/java/org/folio/harvesteradmin/service/HarvestAdminService.java
@@ -133,7 +133,8 @@ public class HarvestAdminService implements RouterCreator, TenantInitHooks {
         .handler(ctx -> getConfigRecordById(vertx, ctx));
     routerBuilder
         .operation("postTransformation")
-        .handler(ctx -> postConfigRecord(vertx, ctx));
+        .handler(ctx -> postConfigRecord(vertx, ctx))
+        .failureHandler(this::routerExceptionResponse);
     routerBuilder
         .operation("putTransformation")
             .handler(ctx -> putConfigRecord(vertx, ctx));

--- a/src/main/resources/openapi/schemas/harvestable.json
+++ b/src/main/resources/openapi/schemas/harvestable.json
@@ -4,7 +4,7 @@
   "properties": {
     "id": {
       "type": "string",
-      "description": "Unique ID for the job definition, will be assigned if not provided."
+      "description": "Unique ID for the job definition. Will be assigned if not provided."
     },
     "name": {
       "type": "string",
@@ -20,40 +20,46 @@
     "storage": {
       "type": "object",
       "description": "Reference to applied storage target.",
-      "properties": {
-        "entityType": {
-          "type": "string",
-          "enum" : [
-            "inventoryStorageEntity"
-          ],
-          "description": "The type of storage.",
-          "default": "inventoryStorageEntity"
+      "anyOf": [
+        {
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "Reference to the ID of the storage engine to use."
+            }
+          }
         },
-        "id": {
-          "type": "string",
-          "description": "Reference to the ID of the storage engine to use."
+        {
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Used for look-up by name as an alternative to reference by id (id will be used if present)."
+            }
+          }
         }
-      },
-      "required": ["id"]
+      ]
     },
     "transformation": {
       "type": "object",
       "description": "Reference to applied transformation pipeline.",
-      "properties": {
-        "entityType": {
-          "type": "string",
-          "enum": [
-            "basicTransformation"
-          ],
-          "description": "The type of transformation.",
-          "default": "basicTransformation"
+      "anyOf": [
+        {
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "Reference to the ID of the transformation pipeline to apply."
+            }
+          }
         },
-        "id": {
-          "type": "string",
-          "description": "Reference to the ID of the transformation pipeline to apply."
+        {
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Used for look-up by name as an alternative to reference by ID (id will be used if present)."
+            }
+          }
         }
-      },
-      "required": ["id"]
+      ]
     },
     "enabled": {
       "type": "string",
@@ -71,11 +77,15 @@
     },
     "metadataPrefix": {
       "type": "string",
-      "description": "For OAI-PMH, a metadata prefix supported by the OAI-PMH service to harvest from."
+      "description": "OAI-PMH only. The metadata prefix supported by the OAI-PMH service to harvest from."
     },
     "oaiSetName": {
       "type": "string",
-      "description": "For OAI-PMH, the name of a record set offered by the OAI-PMH service to harvest from."
+      "description": "OAI-PMH only. The name of a record set offered by the OAI-PMH service to harvest from."
+    },
+    "resumptionToken": {
+      "type": "string",
+      "description": "OAI-PMH only. PMH identifier for fetching the next batch of records."
     },
     "url": {
       "type": "string",
@@ -121,8 +131,18 @@
     },
     "message": {
       "type": "string",
-      "description": "Message summarising results of last run",
+      "description": "Message summarising results of last run.",
       "readOnly": true
+    },
+    "cacheEnabled": {
+      "type": "string",
+      "enum": ["true", "false"],
+      "description": "Whether or not to store incoming records in Harvester's file system."
+    },
+    "diskRun": {
+      "type": "string",
+      "enum": ["true", "false"],
+      "description": "Whether or not to run harvest job from records cached in a previous job run."
     }
   },
   "additionalProperties": true,

--- a/src/main/resources/openapi/schemas/transformation.json
+++ b/src/main/resources/openapi/schemas/transformation.json
@@ -13,6 +13,71 @@
     "description": {
       "type": "string",
       "description": "Details about the pipeline."
+    },
+    "stepAssociations" : {
+      "type": "array",
+      "description": "List of steps that make up the transformation pipeline. In a POST this will be used for attaching the steps to the pipeline. In a PUT this is ignored.",
+      "items": {
+        "type": "object",
+        "anyOf": [
+          {
+            "properties": {
+              "position": {
+                "type": "string",
+                "description": "The steps position in the sequence of steps, starting with number 1."
+              },
+              "step": {
+                "type": "object",
+                "anyOf": [
+                  {
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "description": "The step's numeric id. In a POST it is used for looking up the step and attaching it."
+                      }
+                    }
+                  },
+                  {
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "An alternative to the ID for look-up and attachment. Used in a POST if no ID is present."
+                      }
+                    }
+                  }
+                ]
+              }
+            },
+            "required": ["step"]
+          },
+          {
+            "properties": {
+              "position": {
+                "type": "string",
+                "description": "The steps position in the sequence of steps, starting with number 1."
+              },
+              "stepId": {
+                "type": "string",
+                "description": "The step's numeric id. In a POST it is used for looking up the step and attaching it."
+              }
+            },
+            "required": ["stepId"]
+          },
+          {
+            "properties": {
+              "position": {
+                "type": "string",
+                "description": "The steps position in the sequence of steps, starting with number 1."
+              },
+              "stepName": {
+                "type": "string",
+                "description": "An alternative to the ID for look-up and attachment. Used in a POST if no ID is present."
+              }
+            },
+            "required": ["stepName"]
+          }
+        ]
+      }
     }
   },
   "required": [

--- a/src/main/resources/openapi/schemas/transformation.json
+++ b/src/main/resources/openapi/schemas/transformation.json
@@ -28,6 +28,7 @@
               },
               "step": {
                 "type": "object",
+                "description": "Existing transformation step to include in pipeline, referenced by ID or step name.",
                 "anyOf": [
                   {
                     "properties": {

--- a/src/test/java/org/folio/harvesteradmin/test/HarvesterAdminTestSuite.java
+++ b/src/test/java/org/folio/harvesteradmin/test/HarvesterAdminTestSuite.java
@@ -174,6 +174,70 @@ public class HarvesterAdminTestSuite {
   }
 
   @Test
+  public void canCreateHarvestableWithReferencesById() {
+    SampleId harvestableId = new SampleId(1);
+    JsonObject harvestable =
+        new JsonObject(
+            "{\n"
+                + "  \"id\": \"" + harvestableId.fullId() +"\",\n"
+                + "  \"name\": \"Test harvest job (modhaadm unit tests)\",\n"
+                + "  \"type\": \"oaiPmh\",\n"
+                + "  \"enabled\": \"false\",\n"
+                + "  \"harvestImmediately\": \"false\",\n"
+                + "  \"lastUpdated\": \"2022-12-07T15:20:49.507Z\",\n"
+                + "  \"storage\": {\n"
+                + "    \"entityType\": \"inventoryStorageEntity\",\n"
+                + "    \"id\": \"" + BASE_STORAGE_ID.fullId() + "\"\n"
+                + "  },\n"
+                + "  \"transformation\": {\n"
+                + "    \"entityType\": \"basicTransformation\",\n"
+                + "    \"id\": \"" + BASE_TRANSFORMATION_ID.fullId() + "\"\n"
+                + "  },\n"
+                + "  \"metadataPrefix\": \"marc21\",\n"
+                + "  \"oaiSetName\": \"PALCI_RESHARE\",\n"
+                + "  \"url\": \"https://na01.alma.exlibrisgroup"
+                + ".com/view/oai/01SSHELCO_BLMSBRG/request\",\n"
+                + "  \"dateFormat\": \"yyyy-MM-dd'T'hh:mm:ss'Z'\"\n"
+                + "}"
+        );
+    postConfigRecord(BASE_STORAGE_JSON, THIS_STORAGES_PATH, 201);
+    postConfigRecord(BASE_TRANSFORMATION_JSON, THIS_TRANSFORMATIONS_PATH, 201);
+    postConfigRecord(harvestable, THIS_HARVESTABLES_PATH, 201);
+    getConfigRecord(THIS_HARVESTABLES_PATH, harvestableId.toString(), 200);
+  }
+
+  @Test
+  public void canCreateHarvestableWithReferencesByName() {
+    SampleId harvestableId = new SampleId(1);
+    JsonObject harvestable =
+        new JsonObject(
+            "{\n"
+                + "  \"id\": \"" + harvestableId.fullId() +"\",\n"
+                + "  \"name\": \"Test harvest job (modhaadm unit tests)\",\n"
+                + "  \"type\": \"oaiPmh\",\n"
+                + "  \"enabled\": \"false\",\n"
+                + "  \"harvestImmediately\": \"false\",\n"
+                + "  \"lastUpdated\": \"2022-12-07T15:20:49.507Z\",\n"
+                + "  \"storage\": {\n"
+                + "    \"name\": \"" + BASE_STORAGE_JSON.getString("name") + "\"\n"
+                + "  },\n"
+                + "  \"transformation\": {\n"
+                + "    \"name\": \"" + BASE_TRANSFORMATION_JSON.getString("name") + "\"\n"
+                + "  },\n"
+                + "  \"metadataPrefix\": \"marc21\",\n"
+                + "  \"oaiSetName\": \"PALCI_RESHARE\",\n"
+                + "  \"url\": \"https://na01.alma.exlibrisgroup"
+                + ".com/view/oai/01SSHELCO_BLMSBRG/request\",\n"
+                + "  \"dateFormat\": \"yyyy-MM-dd'T'hh:mm:ss'Z'\"\n"
+                + "}"
+        );
+    postConfigRecord(BASE_STORAGE_JSON, THIS_STORAGES_PATH, 201);
+    postConfigRecord(BASE_TRANSFORMATION_JSON, THIS_TRANSFORMATIONS_PATH, 201);
+    postConfigRecord(harvestable, THIS_HARVESTABLES_PATH, 201);
+    getConfigRecord(THIS_HARVESTABLES_PATH, harvestableId.toString(), 200);
+  }
+
+  @Test
   public void canCreateHarvestableButCannotGetJobLogIfNotRun()
   {
     SampleId harvestableId = new SampleId(1);
@@ -362,6 +426,28 @@ public class HarvesterAdminTestSuite {
     JsonObject pipeline = new JsonObject(BASE_TRANSFORMATION_JSON.encode());
     JsonArray stepAssociations = new JsonArray();
     stepAssociations.add(new JsonObject().put("stepId", SAMPLE_STEP.getString("id")));
+    pipeline.put("stepAssociations", stepAssociations);
+    postConfigRecord(pipeline, THIS_TRANSFORMATIONS_PATH, 201);
+    getConfigRecord(THIS_TRANSFORMATIONS_PATH, BASE_TRANSFORMATION_ID.toString(), 200);
+    JsonObject tsa = new JsonObject(
+        "{\n"
+            + "  \"step\": { \n"
+            + "    \"id\": \"" + SAMPLE_STEP_2_ID + "\"\n"
+            + "  },\n"
+            + "  \"transformation\": \"" + BASE_TRANSFORMATION_ID +"\",\n"
+            + "  \"position\": \"2\"\n"
+            + "}"
+    );
+    postConfigRecord(tsa, THIS_TRANSFORMATIONS_STEPS_PATH, 201);
+  }
+
+  @Test
+  public void canCreateTransformationAssociatedWithAStepByStepName() {
+    postConfigRecord(SAMPLE_STEP, THIS_STEPS_PATH, 201);
+    postConfigRecord(SAMPLE_STEP_2, THIS_STEPS_PATH, 201);
+    JsonObject pipeline = new JsonObject(BASE_TRANSFORMATION_JSON.encode());
+    JsonArray stepAssociations = new JsonArray();
+    stepAssociations.add(new JsonObject().put("stepName", SAMPLE_STEP.getString("name")));
     pipeline.put("stepAssociations", stepAssociations);
     postConfigRecord(pipeline, THIS_TRANSFORMATIONS_PATH, 201);
     getConfigRecord(THIS_TRANSFORMATIONS_PATH, BASE_TRANSFORMATION_ID.toString(), 200);


### PR DESCRIPTION
 - When POSTing a harvestable, it must reference an existing storage and transformation. These references can now be by name as well as by id.
 - when POSTing a transformation, the steps can be included, and these inclusions can now be by step names as well as by step IDs.