### PR TITLE
Don't check acl for failed-records (MODHAADM-33)

### DIFF
--- a/src/main/java/org/folio/harvesteradmin/dataaccess/LegacyHarvesterStorage.java
+++ b/src/main/java/org/folio/harvesteradmin/dataaccess/LegacyHarvesterStorage.java
@@ -290,7 +290,7 @@ public class LegacyHarvesterStorage {
                         + transformation.cause().getMessage());
                   }
                 });
-            if (fatalError.size()>0) {
+            if (fatalError.size() > 0) {
               promise.complete(new ProcessedHarvesterResponsePost(500,fatalError.toString()));
             }
           });

--- a/src/main/java/org/folio/harvesteradmin/dataaccess/responsehandlers/ProcessedHarvesterResponseGetById.java
+++ b/src/main/java/org/folio/harvesteradmin/dataaccess/responsehandlers/ProcessedHarvesterResponseGetById.java
@@ -30,6 +30,7 @@ public class ProcessedHarvesterResponseGetById extends ProcessedHarvesterRespons
               + "] failed to produce a JSON object";
           statusCode = 500;
         } else if (LegacyServiceConfig.filterByTenant
+            && !apiPath.contains("failed-records") // got no acl, but filter enforced via the job
             && (!tenant.equals((apiPath.contains("tsas") // tsas got no acl, check step's instead
             ? transformed.getJsonObject("step").getString("acl")
             : transformed.getString("acl"))))) {


### PR DESCRIPTION
  - Failed records have no ACL, so skip check. (The acl check is already performed on the harvestable level, before retrieving failed records for a job.)