### PR TITLE
Allow job-status property in store-log (MODHAADM-30)

### DIFF
--- a/src/main/resources/openapi/schemas/harvestJobStatus.json
+++ b/src/main/resources/openapi/schemas/harvestJobStatus.json
@@ -2,6 +2,19 @@
   "description": "Status of finished harvest job.",
   "type": "object",
   "properties": {
+    "status": {
+      "type": "string",
+      "description": "The outcome of the harvester job according to Harvester.",
+      "enum": [
+        "NEW",
+        "OK",
+        "WARN",
+        "ERROR",
+        "RUNNING",
+        "FINISHED",
+        "KILLED"
+      ]
+    },
     "finished": {
       "type": "string",
       "description": "ISO formatted timestamp for when the job finished."


### PR DESCRIPTION
  - So that Harvester can provide one when asking mod-harvester-admin to save the Harvester logs.