### PR TITLE
Override harvestable's status, start-date (MODHAADM-30)

### DIFF
--- a/src/main/java/org/folio/harvesteradmin/moduledata/HarvestJob.java
+++ b/src/main/java/org/folio/harvesteradmin/moduledata/HarvestJob.java
@@ -324,6 +324,10 @@ public class HarvestJob extends StoredEntity {
     json.put(HarvestJobField.STARTED.propertyName(), started.toString());
   }
 
+  public void setStarted(String started) {
+    json.put(HarvestJobField.STARTED.propertyName(), started);
+  }
+
   public void setFinished(LocalDateTime finished) {
     setFinished(finished.toString());
   }

--- a/src/main/resources/openapi/schemas/harvestJobStatus.json
+++ b/src/main/resources/openapi/schemas/harvestJobStatus.json
@@ -19,6 +19,10 @@
       "type": "string",
       "description": "ISO formatted timestamp for when the job finished."
     },
+    "started": {
+      "type": "string",
+      "description": "ISO formatted timestamp for when the job started."
+    },
     "amountHarvested": {
       "type": "string",
       "description": "The number of records harvested in the harvest run."


### PR DESCRIPTION
  - when storing previous job and its logs, the status and start-date can be out-dated when fetched from legacy api /harvestables/ -- accept and use these properties if they are provided in the store-history request body to override the out-of-sync pieces.