### PR TITLE
Bug-fixes, transformation POST/PUT (MODHAADM-68)

### DIFF
--- a/src/main/resources/openapi/schemas/transformationPostPut.json
+++ b/src/main/resources/openapi/schemas/transformationPostPut.json
@@ -6,6 +6,11 @@
       "type": "string",
       "description": "Unique record identifier."
     },
+    "acl": {
+      "type": "string",
+      "description": "System controlled access control string.",
+      "readOnly": true
+    },
     "name": {
       "type": "string",
       "description": "Name of the transformation pipeline."


### PR DESCRIPTION
 - allow (and ignore) property 'acl' for transformations like for other record types
 - fix class cast exception that prevents optional resolution of steps by unique name (as alternative to ID)
 - resolve/expand associated steps from provided unique names or IDs to complete step association objects in compliance with the legacy API for transformation objects on PUTs (as already done on POSTs)