### PR TITLE
MODHAADM-117: /harvester-admin/purge-aged-logs hangs in DELETE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,8 +8,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <okapi.version>5.3.0</okapi.version>
         <vertx.version>4.5.3</vertx.version>
-        <maven.compiler.source>18</maven.compiler.source>
-        <maven.compiler.target>18</maven.compiler.target>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -180,6 +178,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
@@ -241,7 +249,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.5.2</version>
                 <configuration>
                     <useSystemClassLoader>false</useSystemClassLoader>
                     <environmentVariables>
@@ -250,15 +258,16 @@
                         <harvester_port>8080</harvester_port>
                         <acl_filter_by_tenant>false</acl_filter_by_tenant>
                     </environmentVariables>
-                    <includes>
-                        <include>**/test/NoHarvesterTestSuite.class</include>
-                    </includes>
+                    <excludes>
+                        <!-- requires harvester at localhost:8080 -->
+                        <exclude>HarvesterIntegrationTest</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.5.2</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/main/java/org/folio/harvesteradmin/moduledata/HarvestJob.java
+++ b/src/main/java/org/folio/harvesteradmin/moduledata/HarvestJob.java
@@ -6,15 +6,14 @@ import io.vertx.sqlclient.templates.TupleMapper;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import org.folio.harvesteradmin.moduledata.database.Tables;
 import org.folio.tlib.postgres.PgCqlDefinition;
 import org.folio.tlib.postgres.cqlfield.PgCqlFieldAlwaysMatches;
-
 
 public class HarvestJob extends StoredEntity {
 
@@ -93,16 +92,18 @@ public class HarvestJob extends StoredEntity {
   /**
    * CREATE TABLE statement.
    */
-  public String makeCreateTableSql(String schema) {
+  @Override
+  public List<String> makeCreateSqls(String schema) {
     StringBuilder columnsDdl = new StringBuilder();
     Stream.of(HarvestJobField.values())
         .forEach(field -> columnsDdl.append(field.pgColumn().getColumnDdl()).append(","));
     columnsDdl.deleteCharAt(columnsDdl.length() - 1); // remove ending comma
-
-    return "CREATE TABLE IF NOT EXISTS " + schema + "." + Tables.harvest_job
+    return List.of(
+        "CREATE TABLE IF NOT EXISTS " + schema + "." + Tables.harvest_job
         + "("
         + columnsDdl
-        + ")";
+        + ")"
+        );
   }
 
   /**

--- a/src/main/java/org/folio/harvesteradmin/moduledata/LogLine.java
+++ b/src/main/java/org/folio/harvesteradmin/moduledata/LogLine.java
@@ -6,12 +6,13 @@ import io.vertx.sqlclient.templates.RowMapper;
 import io.vertx.sqlclient.templates.TupleMapper;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
+import org.folio.harvesteradmin.moduledata.RecordFailure.Column;
 import org.folio.harvesteradmin.moduledata.database.SqlQuery;
 import org.folio.harvesteradmin.moduledata.database.Tables;
 import org.folio.tlib.postgres.PgCqlDefinition;
@@ -131,8 +132,10 @@ public class LogLine extends StoredEntity {
   /**
    * CREATE TABLE SQL template.
    */
-  public String makeCreateTableSql(String schema) {
-    return  "CREATE TABLE IF NOT EXISTS " + schema + "." + Tables.log_statement
+  @Override
+  public List<String> makeCreateSqls(String schema) {
+    return List.of(
+        "CREATE TABLE IF NOT EXISTS " + schema + "." + Tables.log_statement
         + "("
         + LogLineField.ID.columnName() + " UUID PRIMARY KEY, "
         + LogLineField.HARVEST_JOB_ID.columnName() + " UUID NOT NULL REFERENCES "
@@ -142,7 +145,9 @@ public class LogLine extends StoredEntity {
         + LogLineField.LOG_LEVEL.columnName() + " TEXT NOT NULL, "
         + LogLineField.JOB_LABEL.columnName() + " TEXT NOT NULL, "
         + LogLineField.LOG_STATEMENT.columnName() + " TEXT NOT NULL"
-        + ")";
+        + ")",
+        "CREATE INDEX IF NOT EXISTS log_statement_harvest_job_id_idx ON "
+        + schema + "." + Tables.log_statement + "(" + LogLineField.HARVEST_JOB_ID.columnName() + ")");
   }
 
   @Override

--- a/src/main/java/org/folio/harvesteradmin/moduledata/RecordFailure.java
+++ b/src/main/java/org/folio/harvesteradmin/moduledata/RecordFailure.java
@@ -5,6 +5,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.sqlclient.templates.RowMapper;
 import io.vertx.sqlclient.templates.TupleMapper;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -97,10 +98,12 @@ public class RecordFailure extends StoredEntity {
   }
 
   /**
-   * CREATE TABLE statement.
+   * CREATE TABLE and CREATE INDEX statements.
    */
-  public String makeCreateTableSql(String schema) {
-    return "CREATE TABLE IF NOT EXISTS " + schema + "." + Tables.record_failure
+  @Override
+  public List<String> makeCreateSqls(String schema) {
+    return List.of(
+        "CREATE TABLE IF NOT EXISTS " + schema + "." + Tables.record_failure
         + "("
         + Column.id + " UUID PRIMARY KEY, "
         + Column.harvest_job_id + " UUID NOT NULL REFERENCES "
@@ -110,7 +113,9 @@ public class RecordFailure extends StoredEntity {
         + Column.record_errors + " JSONB NOT NULL, "
         + Column.original_record + " TEXT NOT NULL, "
         + Column.transformed_record + " JSONB NOT NULL"
-        + ")";
+        + ")",
+        "CREATE INDEX IF NOT EXISTS record_failure_harvest_job_id_idx ON "
+        + schema + "." + Tables.record_failure + "(" + Column.harvest_job_id + ")");
   }
 
   /**

--- a/src/main/java/org/folio/harvesteradmin/moduledata/StoredEntity.java
+++ b/src/main/java/org/folio/harvesteradmin/moduledata/StoredEntity.java
@@ -6,6 +6,7 @@ import io.vertx.ext.web.validation.RequestParameters;
 import io.vertx.ext.web.validation.ValidationHandler;
 import io.vertx.sqlclient.templates.RowMapper;
 import io.vertx.sqlclient.templates.TupleMapper;
+import java.util.List;
 import java.util.Map;
 
 import org.folio.harvesteradmin.moduledata.database.SqlQuery;
@@ -15,9 +16,9 @@ import org.folio.tlib.postgres.PgCqlQuery;
 public abstract class StoredEntity {
 
   /**
-   * Builds the Postgres DDL SQL for creating a table.
+   * Builds the Postgres DDL SQLs for creating the table and indexes.
    */
-  public abstract String makeCreateTableSql(String schema);
+  public abstract List<String> makeCreateSqls(String schema);
 
   /**
    * Gets vert.x row mapper: Postgres select list results mapped to i.e. JSON or text strings.

--- a/src/main/java/org/folio/harvesteradmin/service/HarvestAdminService.java
+++ b/src/main/java/org/folio/harvesteradmin/service/HarvestAdminService.java
@@ -336,7 +336,8 @@ public class HarvestAdminService implements RouterCreator, TenantInitHooks {
     String tenant = TenantUtil.tenant(routingContext);
     ModuleStorageAccess moduleStorage = new ModuleStorageAccess(vertx, tenant);
     moduleStorage.purgePreviousJobsByAge(untilDate)
-            .onComplete(x -> routingContext.response().setStatusCode(204).end()).mapEmpty();
+            .onSuccess(x -> routingContext.response().setStatusCode(204).end())
+            .onFailure(e -> routingContext.response().setStatusCode(500).end(e.getMessage()));
   }
 
   private Future<Void> getJobLog(Vertx vertx, RoutingContext routingContext) {

--- a/src/test/java/org/folio/harvesteradmin/test/Api.java
+++ b/src/test/java/org/folio/harvesteradmin/test/Api.java
@@ -3,7 +3,7 @@ package org.folio.harvesteradmin.test;
 import static io.restassured.RestAssured.given;
 import static org.folio.harvesteradmin.legacydata.statics.ApiPaths.THIS_HARVESTABLES_PATH;
 import static org.folio.harvesteradmin.legacydata.statics.ApiPaths.THIS_STEPS_PATH;
-import static org.folio.harvesteradmin.test.HarvesterIntegrationTestSuite.*;
+import static org.folio.harvesteradmin.test.HarvesterIntegrationTest.*;
 import static org.folio.harvesteradmin.test.Statics.*;
 
 import io.restassured.response.Response;

--- a/src/test/java/org/folio/harvesteradmin/test/HarvesterIntegrationTest.java
+++ b/src/test/java/org/folio/harvesteradmin/test/HarvesterIntegrationTest.java
@@ -41,14 +41,12 @@ import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 @RunWith( VertxUnitRunner.class )
-public class HarvesterIntegrationTestSuite {
-  private static final Logger logger = LoggerFactory.getLogger( "HarvesterAdminTestSuite" );
+public class HarvesterIntegrationTest {
+  private static final Logger logger = LoggerFactory.getLogger(HarvesterIntegrationTest.class);
 
   static final String TENANT = "mha_test";
   static Vertx vertx;
   public static final Header OKAPI_TENANT = new Header (XOkapiHeaders.TENANT, TENANT);
-
-  public HarvesterIntegrationTestSuite() {}
 
   @ClassRule
   public static PostgreSQLContainer<?> postgresSQLContainer = TenantPgPoolContainer.create();

--- a/src/test/java/org/folio/harvesteradmin/utils/MiscellaneousTest.java
+++ b/src/test/java/org/folio/harvesteradmin/utils/MiscellaneousTest.java
@@ -1,0 +1,42 @@
+package org.folio.harvesteradmin.utils;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.time.Period;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class MiscellaneousTest {
+
+  static Stream<Arguments> getPeriod() {
+    return Stream.of(
+        arguments(null, 4, "DAYS", Period.ofDays(4)),
+        arguments(null, 6, "WEEKS", Period.ofWeeks(6)),
+        arguments(null, 21, "MONTHS", Period.ofMonths(21)),
+        arguments("11 eternities", 8, "WEEKS", Period.ofWeeks(8)),
+        arguments("2 day", 7, "MONTHS", Period.ofDays(2)),
+        arguments("3 days", 7, "MONTHS", Period.ofDays(3)),
+        arguments("4 tag", 7, "MONTHS", Period.ofDays(4)),
+        arguments("5 tage", 7, "MONTHS", Period.ofDays(5)),
+        arguments("12 week", 7, "MONTHS", Period.ofWeeks(12)),
+        arguments("13 weeks", 7, "MONTHS", Period.ofWeeks(13)),
+        arguments("14 woche", 7, "MONTHS", Period.ofWeeks(14)),
+        arguments("15 wochen", 7, "MONTHS", Period.ofWeeks(15)),
+        arguments("22 month", 7, "DAYS", Period.ofMonths(22)),
+        arguments("23 months", 7, "DAYS", Period.ofMonths(23)),
+        arguments("24 monat", 7, "DAYS", Period.ofMonths(24)),
+        arguments("25 monate", 7, "DAYS", Period.ofMonths(25))
+        );
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void getPeriod(String periodAsText, int defaultAmount, String defaultUnit, Period expected) {
+    assertThat(Miscellaneous.getPeriod(periodAsText, defaultAmount, defaultUnit), is(expected));
+  }
+
+}


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODHAADM-117

* There are no indexes for the foreign key relationships from harvest_job to the tables log_statement and record_failure. For each harvest_job record the DELETE query runs a full table scan against the  log_statement and record_failure table.
* It may happen that some other process locks records in the harvest_job, log_statement or record_failure table. This may cause a rollback or wait time to get a lock for the deletion.

Solution:

* Create database indexes to speed up the foreign key lookup during the DELETE statement.
* Skip locked records; they will be tried when the purge API is called the next time.

Implementation:

* Expand DatabaseInit to create database indexes.
* Create purge_previous_jobs_by_age database function with defensive deletion.
* Report 500 HTTP response status code on /harvester-admin/purge-aged-logs failure.
* Rename misleading TestSuite to Test.
* In NoHarvesterTest avoid duplicate code.
* Add MiscellaneousTest#getPeriod.