### PR TITLE
MODHAADM-139: apk upgrade fixing vulns

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,2 @@
 *
-!Dockerfile
-!docker*
-!target/*.jar
+!target/*-fat.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
+# https://github.com/folio-org/folio-tools/tree/master/folio-java-docker/openjdk21
 FROM folioci/alpine-jre-openjdk21:latest
+
+# Install latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
+USER root
+RUN apk upgrade --no-cache
+USER folio
 
 ENV VERTICLE_FILE mod-harvester-admin-fat.jar
 


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODHAADM-139

Run “apk upgrade” in Dockerfile to fix these vulnerabilities:

* https://security.alpinelinux.org/vuln/CVE-2024-45492 expat
* https://security.alpinelinux.org/vuln/CVE-2024-45491 expat
* https://security.alpinelinux.org/vuln/CVE-2025-26519 musl
* https://security.alpinelinux.org/vuln/CVE-2024-8176 expat
* https://security.alpinelinux.org/vuln/CVE-2024-45490 expat
* https://security.alpinelinux.org/vuln/CVE-2024-6119 openssl
* https://security.alpinelinux.org/vuln/CVE-2024-12797 openssl
* https://security.alpinelinux.org/vuln/CVE-2024-50602 expat
* https://security.alpinelinux.org/vuln/CVE-2024-12133 libtasn1
* https://security.alpinelinux.org/vuln/CVE-2024-9143 openssl
* https://security.alpinelinux.org/vuln/CVE-2024-13176 openssl